### PR TITLE
Fix hg38tohg19.py fails to import pyliftover in an uv venv

### DIFF
--- a/program/settings.py
+++ b/program/settings.py
@@ -730,6 +730,7 @@ def init(interactive=False):
         python_executable = "python3"
         python_root = "/usr/bin" # Default
         python_search = [
+            (f'{install_FP}.venv/bin', "python3"),
             ("/usr/local/bin", "python3"),
             ("/opt/homebrew/bin", "python3.11"),
             ("/opt/homebrew/bin", "python3"),


### PR DESCRIPTION
Hi,

I saw the warning that this repo is for the WGSExtract devs but this refactor made the installation on macOS much easier than the current stable release, so many thanks for your efforts!
The installation was smooth following the steps in the README.md on macOS 26.4.1 / M4 Mini:
```
git clone https://github.com/theontho/WGSExtractRepo
cd WGSExtractRepo/
brew bundle
mkdir -p out/download_cache
./dev.py init
./dev.py release-cache
./dev.py launch
```

The app opened without any errors and the BAM import + indexing works.
But I ran into a pyliftover import error when converting a BAM file to a microarray txt at the hg38tohg19.py step.
It looks to me the problem is that program/microarray.py runs hg38tohg19.py as a separate /usr/local/python process and pyliftover is not installed globally but only in the uv venv. My proposed fix is to prepend `{install_FP}/.venv/bin` to the `python_search` list so if the dependencies were installed with uv in a venv then use this `python_root` throughout the project. After applying said fix the hg38tohg19.py step went through and there were no more errors.

Cheers,
Barna

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application initialization on macOS to enhance detection of required tools during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theontho/WGSExtractRepo/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->